### PR TITLE
Page Complete + Impeding list modified

### DIFF
--- a/back/snu_moyeo/urls.py
+++ b/back/snu_moyeo/urls.py
@@ -23,7 +23,10 @@ urlpatterns = [
     path('meetinglist/join/',views.JoinList.as_view()),
     path('meetinglist/history/',views.HistoryList.as_view()),
     path('participate/<int:in_userid>/<int:in_meetingid>/',views.get_participate),
-    
+   
+    #path('pagetemp/',views.TempList.as_view()),
+    path('temp/<int:in_kind>/',views.Temp2View.as_view()),
+    #path('temp2/<int:in_kind>/',views.tempview),
     url(r'^get_auth_token/', obtain_auth_token),
 ]
 

--- a/back/snu_moyeo/urls.py
+++ b/back/snu_moyeo/urls.py
@@ -9,8 +9,6 @@ from django.conf import settings
 
 urlpatterns = [
     url(r'^auth/(?P<mySNU_verification_token>[a-zA-Z0-9]+)/$', views.Authenticate.as_view()),
-    url(r'^get_auth_token/', obtain_auth_token),
-    
     path('sign_up/', views.SignUp.as_view()),
     path('log_in/', views.LogIn.as_view()),
     path('user/', views.SnuUserList.as_view()),
@@ -22,10 +20,7 @@ urlpatterns = [
     path('participate/<int:in_userid>/<int:in_meetingid>/', views.get_participate),
     path('meetinglist/recent/', views.RecentList.as_view()),
     path('meetinglist/impending/', views.ImpendingList.as_view()),
-    
-    path('participate/<int:in_userid>/<int:in_meetingid>/',views.get_participate),
-   
-    path('list/<int:in_kind>/',views.ListMeetingView.as_view()),
+    path('list/<int:in_kind>/', views.ListView.as_view()),
     url(r'^get_auth_token/', obtain_auth_token),
     path('meetinglist/lead/', views.LeadList.as_view()),
     path('meetinglist/join/', views.JoinList.as_view()),

--- a/back/snu_moyeo/views.py
+++ b/back/snu_moyeo/views.py
@@ -211,12 +211,11 @@ class TempList(generics.ListAPIView):
 '''
 
 
-
 class ListMeetingView(APIView):
 
     def get(self,request,in_kind,format=None):
-        temp = Meeting.objects.filter(Q(kind = in_kind) & ~Q(state=4))
+        kind_meeting = Meeting.objects.filter(Q(kind = in_kind) & ~Q(state=4))
         paginator = CustomPagination()
-        result_page = paginator.paginate_queryset(temp,request)
+        result_page = paginator.paginate_queryset(kind_meeting,request)
         serializer = MeetingSerializer(result_page,many=True)
         return paginator.get_paginated_response(serializer.data)

--- a/back/snu_moyeo/views.py
+++ b/back/snu_moyeo/views.py
@@ -169,4 +169,74 @@ def get_participate(request, in_userid, in_meetingid):
     return HttpResponse(participate_id, status = status.HTTP_200_OK)
 
 
-        
+class CustomPagination(PageNumberPagination):
+    page_size = 2
+    page_size_query_param = 'page_size'
+    max_page_size = 4
+
+    def get_paginated_response(self, data):
+        return Response({
+            'links': {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link()
+            },
+            'count': self.page.paginator.count,
+            'page_size': self.page_size,
+            'results': data
+        })
+
+
+class CustomtempPagination(PageNumberPagination):
+    page_size = 3
+    page_size_query_param = 'page_size'
+    max_page_size = 3
+
+    def get_paginated_response(self, data):
+        print(data)
+        return Response({
+            'links': {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link()
+            },
+            'count': self.page.paginator.count,
+            'page_size': self.page_size,
+            'results': data
+        })
+
+
+class TempList(generics.ListAPIView):
+    serializer_class = MeetingSerializer
+    pagination_class = CustomPagination
+    
+    def get_queryset(self):
+        temp_meeting = Meeting.objects.filter(~Q(state=4))
+        return temp_meeting
+
+'''
+def tempview(request,in_kind):
+    paginator = CustomtempPagination()
+    paginator.page_size = 2
+    meeting_objects = Meeting.objects.filter(~Q(state=4) and Q(kind=in_kind))
+    print("hi1")
+    print(type(meeting_objects))
+    result_page = paginator.paginate_queryset(queryset = meeting_objects,request= request)
+    print("hi2")
+    serializer = MeetingSerializer(result_page, many= True)
+    return paginator.get_paginated_response(serializer.data)
+'''
+class Temp2View(APIView):
+
+    def get(self,request,in_kind,format=None):
+        temp = Meeting.objects.filter(Q(kind = in_kind) & ~Q(state=4))
+        paginator = CustomtempPagination()
+        result_page = paginator.paginate_queryset(temp,request)
+        serializer = MeetingSerializer(result_page,many=True)
+        print(serializer.data)
+        return paginator.get_paginated_response(serializer.data)
+'''
+class Temp3View(ListCreateAPIView):
+        def list (self,request,in_kind):
+            queryset = self.get_queryset()
+            paged_queryset = self.paginate_queryset(queryset)
+
+            '''

--- a/back/snu_moyeo/views.py
+++ b/back/snu_moyeo/views.py
@@ -165,22 +165,6 @@ class HistoryList (generics.ListAPIView):
             return history_user.meetings.all().filter(Q(state = BREAK_UP))
         return Meeting.objects.none()
 
-def get_participate(request, in_userid, in_meetingid):
-    participate_obj1 = Participate.objects.filter(Q(user_id_id = in_userid)) #here
-    participateList1 = participate_obj1.values()
-    participate_obj2 = participate_obj1.filter(Q(meeting_id_id = in_meetingid))
-    participateList2 = participate_obj2.values()
-    #print(participate_obj2.values())
-
-    if len(participateList2)==0 :
-        content = {}
-        return HttpResponse(content,status = status.HTTP_404_NOT_FOUND)
-    participate_id = participateList2[0]['id']
-
-
-    return HttpResponse(participate_id, status = status.HTTP_200_OK)
-
-
 
 class CustomPagination(PageNumberPagination):
     page_size = 3
@@ -211,7 +195,7 @@ class TempList(generics.ListAPIView):
 '''
 
 
-class ListMeetingView(APIView):
+class ListView(APIView):
 
     def get(self,request,in_kind,format=None):
         kind_meeting = Meeting.objects.filter(Q(kind = in_kind) & ~Q(state=4))


### PR DESCRIPTION
1. 각 kind 별로의 List Page 표시를 완료했습니다.

- /list/<int:kind>/?page=N
=> kind 에 해당하는 N 번째 page 의 meeting list가 출력됩니다.

- 각 페이지에서 response의 변수로
"links" 의 "next", "previous: 다음 페이지와 이전 페이지의 url 을 명시
"count" : 모든 페이지의 meeting 수의 합
"page_size": 한 페이지당 표시되는 meeting의 수 (test를 위해 3으로 설정)
"results" :  meeting 정보

*사진 참조 바랍
![스크린샷, 2019-05-18 23-18-37](https://user-images.githubusercontent.com/29303833/57971020-7e88f800-79c3-11e9-9d0a-b8af0b70fb3e.png)

2. meetinglist/impending에서 due의 역순으로 출력되던 문제를 해결했습니다
