### PR TITLE
comment len & unique email and phone number

### DIFF
--- a/back/snu_moyeo/models.py
+++ b/back/snu_moyeo/models.py
@@ -82,7 +82,7 @@ class Comment (models.Model):
     writer = models.ForeignKey('SnuUser', on_delete = models.CASCADE)
     writerid = models.IntegerField(default = -1)
     meetingid = models.ForeignKey('Meeting', related_name = 'comments', on_delete = models.CASCADE)
-    content = models.CharField(max_length = 100)
+    content = models.CharField(max_length = 400)
 
 
 class Report (models.Model) :

--- a/back/snu_moyeo/views.py
+++ b/back/snu_moyeo/views.py
@@ -81,6 +81,10 @@ class SendEmail(mixins.ListModelMixin, mixins.CreateModelMixin, generics.Generic
 
     def get(self, request, email):
         user = request.user
+        
+        if (len(SnuUser.objects.filter(email = email)) != 0) :
+            return Response('Duplicate Email', status = 400)
+
         email_token = random.randint(10000000, 99999999)
         send_mail('SnuMoyeo Authenticate', 'Authentication Code : ' + str(email_token),
                 'toro.8906@gmail.com', [email], fail_silently = False)
@@ -113,6 +117,10 @@ class SendPhone(mixins.ListModelMixin, mixins.CreateModelMixin, generics.Generic
 
     def get(self, request, phone_number):
         user = request.user
+        
+        if (len(SnuUser.objects.filter(phone_number = phone_number)) != 0) :
+            return Response('Duplicate phone number', status = 400)
+
         phone_token = random.randint(10000000, 99999999)
         send_message(phone_number, phone_token)
 


### PR DESCRIPTION
댓글 길이 제한을 늘이며,
이제 테스트시 풀어놓았던 가입 시 제한을 재설정했습니다.
이메일과 핸드폰 번호는 이제 unique를 보장합니다 